### PR TITLE
chore: release v0.2.1

### DIFF
--- a/usb-host/CHANGELOG.md
+++ b/usb-host/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/drivercraft/CrabUSB/compare/crab-usb-v0.2.0...crab-usb-v0.2.1) - 2025-08-07
+
+### Added
+
+- libusb transfer ok
+
+### Other
+
+- update
+- fmt code
+
 ## [0.2.0](https://github.com/drivercraft/CrabUSB/compare/crab-usb-v0.1.3...crab-usb-v0.2.0) - 2025-08-05
 
 ### Other

--- a/usb-host/Cargo.toml
+++ b/usb-host/Cargo.toml
@@ -7,7 +7,7 @@ keywords = ["os", "usb", "xhci", "driver"]
 license = "MIT"
 name = "crab-usb"
 repository = "https://github.com/drivercraft/CrabUSB"
-version = "0.2.0"
+version = "0.2.1"
 
 [features]
 libusb = ["libusb1-sys"]

--- a/usb-if/CHANGELOG.md
+++ b/usb-if/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1](https://github.com/drivercraft/CrabUSB/compare/usb-if-v0.2.0...usb-if-v0.2.1) - 2025-08-07
+
+### Added
+
+- libusb transfer ok
+
 ## [0.2.0](https://github.com/drivercraft/CrabUSB/compare/usb-if-v0.1.0...usb-if-v0.2.0) - 2025-08-05
 
 ### Other

--- a/usb-if/Cargo.toml
+++ b/usb-if/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license.workspace = true
 name = "usb-if"
 repository.workspace = true
-version = "0.2.0"
+version = "0.2.1"
 
 [dependencies]
 futures = {workspace = true, features = ["alloc"]}


### PR DESCRIPTION



## 🤖 New release

* `usb-if`: 0.2.0 -> 0.2.1 (✓ API compatible changes)
* `crab-usb`: 0.2.0 -> 0.2.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `usb-if`

<blockquote>

## [0.2.1](https://github.com/drivercraft/CrabUSB/compare/usb-if-v0.2.0...usb-if-v0.2.1) - 2025-08-07

### Added

- libusb transfer ok
</blockquote>

## `crab-usb`

<blockquote>

## [0.2.1](https://github.com/drivercraft/CrabUSB/compare/crab-usb-v0.2.0...crab-usb-v0.2.1) - 2025-08-07

### Added

- libusb transfer ok

### Other

- update
- fmt code
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).