### PR TITLE
Use default LANGID for string descriptor requests

### DIFF
--- a/usb-host/src/host/libusb/device.rs
+++ b/usb-host/src/host/libusb/device.rs
@@ -314,6 +314,7 @@ fn libusb_device_desc_to_desc(
         usb_version: desc.bcdUSB,
         max_packet_size_0: desc.bMaxPacketSize0,
         device_version: desc.bcdDevice,
+        default_language: 0,
     })
 }
 

--- a/usb-host/src/host/mod.rs
+++ b/usb-host/src/host/mod.rs
@@ -1,7 +1,7 @@
 mod common;
 #[cfg(feature = "libusb")]
 mod libusb;
-mod xhci;
+pub mod xhci;
 
 pub use common::*;
 

--- a/usb-host/src/host/xhci/device.rs
+++ b/usb-host/src/host/xhci/device.rs
@@ -30,11 +30,6 @@ use crate::{
     },
 };
 
-/// Validate a USB LANGID per the rules:
-/// - Primary language is bits [9:0]
-/// - Sublanguage is bits [15:10]
-/// - Invalid if primary is 0, or in 0x62..=0xFE, or in 0x100..=0x3FF
-/// - Invalid if sublanguage is 0
 fn is_valid_langid(langid: u16) -> bool {
     let primary_lang = langid & 0x03ff;
     let sub_lang = langid >> 10;
@@ -191,9 +186,11 @@ impl usb_if::host::Device for Device {
             if index != 0 && !is_valid_langid(language_id) {
                 return Err(USBError::Other("Invalid language ID".into()));
             }
+
             let mut data = alloc::vec![0u8; 256];
             self.get_descriptor(DescriptorType::STRING, index, language_id, &mut data)
                 .await?;
+
             let res = decode_string_descriptor(&data).map_err(|e| USBError::Other(e.into()))?;
             Ok(res)
         }

--- a/usb-host/src/host/xhci/device.rs
+++ b/usb-host/src/host/xhci/device.rs
@@ -30,6 +30,25 @@ use crate::{
     },
 };
 
+/// Validate a USB LANGID per the rules:
+/// - Primary language is bits [9:0]
+/// - Sublanguage is bits [15:10]
+/// - Invalid if primary is 0, or in 0x62..=0xFE, or in 0x100..=0x3FF
+/// - Invalid if sublanguage is 0
+fn is_valid_langid(langid: u16) -> bool {
+    let primary_lang = langid & 0x03ff;
+    let sub_lang = langid >> 10;
+
+    if primary_lang == 0
+        || (0x62..=0xFE).contains(&primary_lang)
+        || (0x100..=0x3FF).contains(&primary_lang)
+    {
+        return false;
+    }
+
+    sub_lang != 0
+}
+
 pub struct Device {
     id: SlotId,
     root: RootHub,
@@ -169,6 +188,9 @@ impl usb_if::host::Device for Device {
         language_id: u16,
     ) -> futures::future::LocalBoxFuture<'_, Result<String, USBError>> {
         async move {
+            if index != 0 && !is_valid_langid(language_id) {
+                return Err(USBError::Other("Invalid language ID".into()));
+            }
             let mut data = alloc::vec![0u8; 256];
             self.get_descriptor(DescriptorType::STRING, index, language_id, &mut data)
                 .await?;

--- a/usb-host/src/lib.rs
+++ b/usb-host/src/lib.rs
@@ -12,7 +12,7 @@ pub use usb_if::transfer::*;
 mod _macros;
 
 pub mod err;
-mod host;
+pub mod host;
 
 pub use futures::future::BoxFuture;
 pub use host::*;

--- a/usb-if/src/descriptor/mod.rs
+++ b/usb-if/src/descriptor/mod.rs
@@ -58,6 +58,7 @@ pub struct DeviceDescriptor {
     pub product_string_index: Option<NonZero<u8>>,
     pub serial_number_string_index: Option<NonZero<u8>>,
     pub num_configurations: u8,
+    pub default_language: u16,
 }
 
 impl DeviceDescriptor {
@@ -182,6 +183,7 @@ impl From<parser::DeviceDescriptor> for DeviceDescriptor {
             product_string_index: desc.product_string_index(),
             serial_number_string_index: desc.serial_number_string_index(),
             num_configurations: desc.num_configurations(),
+            default_language: 0,
         }
     }
 }


### PR DESCRIPTION
Gets default LANGID and then uses it for the string descriptor requests, fixes #21 