### PR TITLE
chore: release

### DIFF
--- a/usb-host/CHANGELOG.md
+++ b/usb-host/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2](https://github.com/drivercraft/CrabUSB/compare/crab-usb-v0.3.1...crab-usb-v0.3.2) - 2025-08-12
+
+### Other
+
+- enhance error handling in libusb context and error modules ([#26](https://github.com/drivercraft/CrabUSB/pull/26))
+
 ## [0.3.0](https://github.com/drivercraft/CrabUSB/compare/crab-usb-v0.2.3...crab-usb-v0.3.0) - 2025-08-09
 
 ### Fixed

--- a/usb-host/Cargo.toml
+++ b/usb-host/Cargo.toml
@@ -7,7 +7,7 @@ keywords = ["os", "usb", "xhci", "driver"]
 license = "MIT"
 name = "crab-usb"
 repository = "https://github.com/drivercraft/CrabUSB"
-version = "0.3.1"
+version = "0.3.2"
 
 [features]
 libusb = ["libusb1-sys"]

--- a/usb-if/CHANGELOG.md
+++ b/usb-if/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/drivercraft/CrabUSB/compare/usb-if-v0.3.0...usb-if-v0.3.1) - 2025-08-12
+
+### Other
+
+- enhance error handling in libusb context and error modules ([#26](https://github.com/drivercraft/CrabUSB/pull/26))
+
 ## [0.3.0](https://github.com/drivercraft/CrabUSB/compare/usb-if-v0.2.2...usb-if-v0.3.0) - 2025-08-08
 
 ### Other

--- a/usb-if/Cargo.toml
+++ b/usb-if/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license.workspace = true
 name = "usb-if"
 repository.workspace = true
-version = "0.3.0"
+version = "0.3.1"
 
 [dependencies]
 futures = {workspace = true, features = ["alloc"]}


### PR DESCRIPTION



## 🤖 New release

* `usb-if`: 0.3.0 -> 0.3.1 (✓ API compatible changes)
* `crab-usb`: 0.3.1 -> 0.3.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `usb-if`

<blockquote>

## [0.3.1](https://github.com/drivercraft/CrabUSB/compare/usb-if-v0.3.0...usb-if-v0.3.1) - 2025-08-12

### Other

- enhance error handling in libusb context and error modules ([#26](https://github.com/drivercraft/CrabUSB/pull/26))
</blockquote>

## `crab-usb`

<blockquote>

## [0.3.2](https://github.com/drivercraft/CrabUSB/compare/crab-usb-v0.3.1...crab-usb-v0.3.2) - 2025-08-12

### Other

- enhance error handling in libusb context and error modules ([#26](https://github.com/drivercraft/CrabUSB/pull/26))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).