### PR TITLE
chore: release

### DIFF
--- a/usb-host/CHANGELOG.md
+++ b/usb-host/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1](https://github.com/drivercraft/CrabUSB/compare/crab-usb-v0.6.0...crab-usb-v0.6.1) - 2026-01-28
+
+### Other
+
+- ♻️ refactor(hub): remove unused RouteString and clean up HubParams structure
+- ♻️ refactor(hub): enhance HubInfo structure and update initialization logic
+
 ## [0.6.0](https://github.com/drivercraft/CrabUSB/compare/crab-usb-v0.5.0...crab-usb-v0.6.0) - 2026-01-27
 
 ### Added

--- a/usb-host/Cargo.toml
+++ b/usb-host/Cargo.toml
@@ -7,7 +7,7 @@ keywords = ["os", "usb", "xhci", "driver"]
 license = "MIT"
 name = "crab-usb"
 repository = "https://github.com/drivercraft/CrabUSB"
-version = "0.6.0"
+version = "0.6.1"
 
 [features]
 aggressive_usb_reset = []

--- a/usb-if/CHANGELOG.md
+++ b/usb-if/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1](https://github.com/drivercraft/CrabUSB/compare/usb-if-v0.5.0...usb-if-v0.5.1) - 2026-01-28
+
+### Other
+
+- ♻️ refactor(hub): remove unused RouteString and clean up HubParams structure
+
 ## [0.5.0](https://github.com/drivercraft/CrabUSB/compare/usb-if-v0.4.0...usb-if-v0.5.0) - 2026-01-27
 
 ### Other

--- a/usb-if/Cargo.toml
+++ b/usb-if/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license.workspace = true
 name = "usb-if"
 repository.workspace = true
-version = "0.5.0"
+version = "0.5.1"
 
 [dependencies]
 anyhow = { version = "1", default-features = false}


### PR DESCRIPTION



## 🤖 New release

* `usb-if`: 0.5.0 -> 0.5.1 (✓ API compatible changes)
* `crab-usb`: 0.6.0 -> 0.6.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `usb-if`

<blockquote>

## [0.5.1](https://github.com/drivercraft/CrabUSB/compare/usb-if-v0.5.0...usb-if-v0.5.1) - 2026-01-28

### Other

- ♻️ refactor(hub): remove unused RouteString and clean up HubParams structure
</blockquote>

## `crab-usb`

<blockquote>

## [0.6.1](https://github.com/drivercraft/CrabUSB/compare/crab-usb-v0.6.0...crab-usb-v0.6.1) - 2026-01-28

### Other

- ♻️ refactor(hub): remove unused RouteString and clean up HubParams structure
- ♻️ refactor(hub): enhance HubInfo structure and update initialization logic
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).