### PR TITLE
[codex] support variable packet lengths for isochronous transfers

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -2,7 +2,9 @@
 runner = "cargo osrun"
 
 [alias]
-test-hub = "test -p test_hub --test test --target aarch64-unknown-none-softfloat"
+# `cargo-osrun` resolves implicit QEMU configs from the workspace root, so the
+# hub test needs an explicit package-local config to attach the xHCI topology.
+test-hub = "test -p test_hub --test test --target aarch64-unknown-none-softfloat -- -c ${workspace}/test_crates/test_hub/.qemu.toml"
 test-uboot = "test -p test_hub --test test --target aarch64-unknown-none-softfloat -- uboot"
 test-dwc = "test -p test_hub --test test_dwc --target aarch64-unknown-none-softfloat -- uboot"
 test-uvc-uboot = "test -p test_xhci_uvc --test test --target aarch64-unknown-none-softfloat -- uboot | tee target/uvc.log"

--- a/usb-device/uvc/src/frame.rs
+++ b/usb-device/uvc/src/frame.rs
@@ -1,8 +1,8 @@
 use crate::descriptors::payload_header_flags as flags;
 use alloc::vec::Vec;
-use usb_if::err::TransferError;
 use core::fmt::Debug;
 use log::{debug, warn};
+use usb_if::err::TransferError;
 
 /// UVC 载荷头（2.4.3.3）
 #[derive(Debug, Clone, Default)]

--- a/usb-host/src/backend/kmod/hub/device.rs
+++ b/usb-host/src/backend/kmod/hub/device.rs
@@ -762,8 +762,7 @@ impl HubDevice {
                 return Err(USBError::from("Device disconnected during enable wait"));
             }
 
-            self.kernel
-                .delay(Duration::from_millis(CHECK_INTERVAL_MS));
+            self.kernel.delay(Duration::from_millis(CHECK_INTERVAL_MS));
         }
 
         warn!("Port {} enable timeout after {}ms", port_id, MAX_WAIT_MS);

--- a/usb-host/src/backend/kmod/xhci/endpoint.rs
+++ b/usb-host/src/backend/kmod/xhci/endpoint.rs
@@ -113,11 +113,11 @@ impl Endpoint {
         TransferId(self.ring.enque_transfer(trb))
     }
 
-    fn enque_iso(&mut self, bus_addr: u64, buff_len: usize, num_iso_packets: usize) -> TransferId {
-        if buff_len == 0 || num_iso_packets < 2 {
-            self.enque_iso_trb(bus_addr, buff_len)
+    fn enque_iso(&mut self, bus_addr: u64, packet_lengths: &[usize]) -> TransferId {
+        if packet_lengths.len() <= 1 {
+            self.enque_iso_trb(bus_addr, packet_lengths.first().copied().unwrap_or(0))
         } else {
-            self.enque_iso_multi(bus_addr, buff_len, num_iso_packets)
+            self.enque_iso_multi(bus_addr, packet_lengths)
         }
     }
 
@@ -136,34 +136,18 @@ impl Endpoint {
         let trb = transfer::Allowed::Isoch(trb);
         self.enque_trb(trb)
     }
-    fn enque_iso_multi(&mut self, bus_addr: u64, len: usize, num_iso_packets: usize) -> TransferId {
-        let len = len as u64;
-        let packet_size = if len == 0 {
-            0
-        } else {
-            len.div_ceil(num_iso_packets as u64)
-        };
-
+    fn enque_iso_multi(&mut self, bus_addr: u64, packet_lengths: &[usize]) -> TransferId {
         let mut id = TransferId(BusAddr(0));
+        let mut offset = 0u64;
 
-        for i in 0..num_iso_packets {
-            let i = i as u64;
-            let offset = i * packet_size;
-            if offset >= len {
-                break; // 避免越界
-            }
-            let remaining = len - offset;
-            let current_size = if remaining >= packet_size {
-                packet_size
-            } else {
-                remaining
-            };
+        for (index, packet_length) in packet_lengths.iter().copied().enumerate() {
+            let current_size = packet_length as u64;
 
             if current_size > 0 {
                 let current_addr = bus_addr + offset;
-                let is_last = (i == num_iso_packets as u64 - 1) || (offset + current_size >= len);
+                let is_last = index + 1 == packet_lengths.len();
 
-                if i == 0 {
+                if index == 0 {
                     // 第一个TRB必须是Isoch TRB
                     id = self.enque_iso_trb(current_addr, current_size as _);
                 } else {
@@ -180,6 +164,8 @@ impl Endpoint {
                     id = self.enque_trb(trb);
                 }
             }
+
+            offset += current_size;
         }
 
         id
@@ -294,8 +280,8 @@ impl EndpointOp for Endpoint {
                 );
                 handle.0 = self.ring.enque_transfer(trb);
             }
-            TransferKind::Isochronous { num_pkgs } => {
-                handle = self.enque_iso(data_bus_addr, data_len, *num_pkgs);
+            TransferKind::Isochronous { packet_lengths } => {
+                handle = self.enque_iso(data_bus_addr, packet_lengths);
             }
         }
         self.transfers.insert(handle, transfer);

--- a/usb-host/src/backend/ty/ep/iso.rs
+++ b/usb-host/src/backend/ty/ep/iso.rs
@@ -1,3 +1,4 @@
+use alloc::vec::Vec;
 use core::ptr::NonNull;
 
 use usb_if::{err::TransferError, transfer::Direction};
@@ -21,10 +22,31 @@ impl EndpointIsoIn {
         Ok(n)
     }
 
+    pub async fn submit_and_wait_with_packet_lengths(
+        &mut self,
+        packets: &mut [u8],
+        packet_lengths: &[usize],
+    ) -> Result<usize, TransferError> {
+        let t = self
+            .submit_with_packet_lengths(packets, packet_lengths)?
+            .await?;
+        let n = t.transfer_len;
+        Ok(n)
+    }
+
     pub fn submit(
         &mut self,
         packets: &mut [u8],
         num_packets: usize,
+    ) -> Result<TransferHandle<'_>, TransferError> {
+        let packet_lengths = even_packet_lengths(packets.len(), num_packets);
+        self.submit_with_packet_lengths(packets, &packet_lengths)
+    }
+
+    pub fn submit_with_packet_lengths(
+        &mut self,
+        packets: &mut [u8],
+        packet_lengths: &[usize],
     ) -> Result<TransferHandle<'_>, TransferError> {
         let buff = if packets.is_empty() {
             None
@@ -34,7 +56,7 @@ impl EndpointIsoIn {
 
         let transfer = self.raw.new_transfer(
             TransferKind::Isochronous {
-                num_pkgs: num_packets,
+                packet_lengths: packet_lengths.to_vec(),
             },
             Direction::In,
             buff,
@@ -65,10 +87,31 @@ impl EndpointIsoOut {
         Ok(n)
     }
 
+    pub async fn submit_and_wait_with_packet_lengths(
+        &mut self,
+        packets: &[u8],
+        packet_lengths: &[usize],
+    ) -> Result<usize, TransferError> {
+        let t = self
+            .submit_with_packet_lengths(packets, packet_lengths)?
+            .await?;
+        let n = t.transfer_len;
+        Ok(n)
+    }
+
     pub fn submit(
         &mut self,
         packets: &[u8],
         num_packets: usize,
+    ) -> Result<TransferHandle<'_>, TransferError> {
+        let packet_lengths = even_packet_lengths(packets.len(), num_packets);
+        self.submit_with_packet_lengths(packets, &packet_lengths)
+    }
+
+    pub fn submit_with_packet_lengths(
+        &mut self,
+        packets: &[u8],
+        packet_lengths: &[usize],
     ) -> Result<TransferHandle<'_>, TransferError> {
         let buff = if packets.is_empty() {
             None
@@ -80,7 +123,7 @@ impl EndpointIsoOut {
         };
         let transfer = self.raw.new_transfer(
             TransferKind::Isochronous {
-                num_pkgs: num_packets,
+                packet_lengths: packet_lengths.to_vec(),
             },
             Direction::Out,
             buff,
@@ -93,4 +136,24 @@ impl From<EndpointBase> for EndpointIsoOut {
     fn from(raw: EndpointBase) -> Self {
         Self { raw }
     }
+}
+
+fn even_packet_lengths(total_len: usize, num_packets: usize) -> Vec<usize> {
+    if num_packets == 0 {
+        return Vec::new();
+    }
+
+    if total_len == 0 {
+        return alloc::vec![0; num_packets];
+    }
+
+    let packet_size = total_len.div_ceil(num_packets);
+    let mut remaining = total_len;
+    let mut packet_lengths = Vec::with_capacity(num_packets);
+    for _ in 0..num_packets {
+        let current = remaining.min(packet_size);
+        packet_lengths.push(current);
+        remaining = remaining.saturating_sub(current);
+    }
+    packet_lengths
 }

--- a/usb-host/src/backend/ty/transfer.rs
+++ b/usb-host/src/backend/ty/transfer.rs
@@ -1,3 +1,5 @@
+use alloc::vec::Vec;
+
 use usb_if::host::ControlSetup;
 
 #[derive(Clone)]
@@ -5,13 +7,20 @@ pub enum TransferKind {
     Control(ControlSetup),
     Bulk,
     Interrupt,
-    Isochronous { num_pkgs: usize },
+    Isochronous { packet_lengths: Vec<usize> },
 }
 
 impl TransferKind {
     pub fn get_control(&self) -> Option<&ControlSetup> {
         match self {
             TransferKind::Control(setup) => Some(setup),
+            _ => None,
+        }
+    }
+
+    pub fn iso_packet_lengths(&self) -> Option<&[usize]> {
+        match self {
+            TransferKind::Isochronous { packet_lengths } => Some(packet_lengths),
             _ => None,
         }
     }

--- a/usb-host/src/backend/umod/endpoint.rs
+++ b/usb-host/src/backend/umod/endpoint.rs
@@ -43,7 +43,7 @@ impl EndpointImpl {
     ) -> Result<Arc<TransferHandleRaw>, TransferError> {
         // 对于 ISO transfer，需要指定 iso_packets 数量
         let iso_packets = match &transfer.kind {
-            TransferKind::Isochronous { num_pkgs } => *num_pkgs as i32,
+            TransferKind::Isochronous { packet_lengths } => packet_lengths.len() as i32,
             _ => 0,
         };
 
@@ -150,8 +150,8 @@ impl EndpointImpl {
                     )
                 };
             }
-            TransferKind::Isochronous { num_pkgs } => {
-                let num_pkgs = *num_pkgs;
+            TransferKind::Isochronous { packet_lengths } => {
+                let num_pkgs = packet_lengths.len();
                 trace!(
                     "Filling ISO transfer: buff@{:p} num_pkgs={}, data_len={}",
                     buffer, num_pkgs, data_len
@@ -170,11 +170,9 @@ impl EndpointImpl {
                     )
                 };
 
-                // 设置每个 ISO packet 的长度，防止溢出
-                let packet_size = data_len as i32 / num_pkgs as i32;
-                for i in 0..num_pkgs {
+                for (i, packet_length) in packet_lengths.iter().copied().enumerate() {
                     let packet = unsafe { &mut *(*trans_ptr).iso_packet_desc.as_mut_ptr().add(i) };
-                    packet.length = packet_size as u32;
+                    packet.length = packet_length as u32;
                 }
             }
         }

--- a/usb-host/src/device.rs
+++ b/usb-host/src/device.rs
@@ -22,6 +22,10 @@ pub struct DeviceInfo {
 }
 
 impl DeviceInfo {
+    pub fn id(&self) -> usize {
+        self.inner.id()
+    }
+
     pub fn descriptor(&self) -> &DeviceDescriptor {
         self.inner.descriptor()
     }


### PR DESCRIPTION
## What changed
- carry explicit per-packet lengths through `TransferKind::Isochronous` instead of only storing a packet count
- add `submit_with_packet_lengths` helpers for isochronous endpoints while keeping the even-split fallback API
- update the xHCI and userspace backends to enqueue/fill ISO packets using the provided packet lengths
- expose `DeviceInfo::id()` for callers that need a stable device identifier

## Why
Some isochronous workloads need uneven packet sizing, but the previous transfer model only kept `num_pkgs` and then recomputed even slices in each backend. That could not represent variable packet layouts correctly.

## Impact
- callers can now submit isochronous transfers with exact packet boundaries
- backend packet descriptors and TRB layout stay aligned with the caller-provided packet sizes
- existing callers that only know `num_packets` still work through the even-split helper

## Validation
- `cargo fmt --check`
- `cargo check -p crab-usb --lib`
- `cargo check -p crab-uvc --lib`
- attempted `cargo test -p crab-usb -p crab-uvc` but it still fails in pre-existing `crab-uvc` tests/examples (`VideoFormat::*` variant resolution and missing `USBHost::new_libusb`), unrelated to this diff
