### PR TITLE
♻️ refactor(device): introduce ProbedDevice enum to distinguish hubs from devices

### DIFF
--- a/test_crates/test_hub/tests/test.rs
+++ b/test_crates/test_hub/tests/test.rs
@@ -68,8 +68,11 @@ mod tests {
                 sleep(Duration::from_millis(100)).await;
             }
 
-            for info in ls {
-                info!("{info:#x?}");
+            for probed in ls {
+                info!("{probed:#x?}");
+                let Some(info) = probed.into_device_info() else {
+                    continue;
+                };
 
                 let mut interface_desc = None;
                 let mut config_desc: Option<ConfigurationDescriptor> = None;

--- a/test_crates/test_hub/tests/test_dwc.rs
+++ b/test_crates/test_hub/tests/test_dwc.rs
@@ -83,8 +83,11 @@ mod tests {
                 sleep(Duration::from_millis(1000)).await;
             }
 
-            for info in ls {
-                info!("{info:#x?}");
+            for probed in ls {
+                info!("{probed:#x?}");
+                let Some(info) = probed.into_device_info() else {
+                    continue;
+                };
 
                 let mut interface_desc = None;
                 let mut config_desc: Option<ConfigurationDescriptor> = None;

--- a/test_crates/test_libusb/tests/test.rs
+++ b/test_crates/test_libusb/tests/test.rs
@@ -16,8 +16,11 @@ async fn test() {
 
     let mut info: Option<DeviceInfo> = None;
 
-    for device in ls {
-        println!("{device:?}");
+    'devices: for probed in ls {
+        println!("{probed:?}");
+        let Some(device) = probed.into_device_info() else {
+            continue;
+        };
 
         for iface in device.interface_descriptors().cloned().collect::<Vec<_>>() {
             println!("  Interface: {:?}", iface.class());
@@ -30,7 +33,7 @@ async fn test() {
             if matches!(iface.class(), Class::Video | Class::AudioVideo(_)) {
                 info!("Found video interface: {iface:?}");
                 info = Some(device);
-                break;
+                break 'devices;
             }
         }
     }

--- a/test_crates/test_libusb_uvc/src/main.rs
+++ b/test_crates/test_libusb_uvc/src/main.rs
@@ -26,7 +26,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // 查找 UVC 设备
     let mut uvc_device = None;
-    for device_info in devices {
+    for probed in devices {
+        let Some(device_info) = probed.into_device_info() else {
+            continue;
+        };
         info!(
             "Checking device: VID={:04x}, PID={:04x}",
             device_info.vendor_id(),

--- a/test_crates/test_xhci_uvc/tests/test.rs
+++ b/test_crates/test_xhci_uvc/tests/test.rs
@@ -52,7 +52,10 @@ mod tests {
                 let ls2 = host.probe_devices().await.unwrap();
                 if !ls2.is_empty() {
                     info!("found {} devices", ls2.len());
-                    devices = ls2;
+                    devices = ls2
+                        .into_iter()
+                        .filter_map(|device| device.into_device_info())
+                        .collect();
                     break;
                 }
                 spin_delay(Duration::from_millis(100));

--- a/usb-device/hid/keyboard/examples/keyboard.rs
+++ b/usb-device/hid/keyboard/examples/keyboard.rs
@@ -13,8 +13,11 @@ async fn main() {
 
     let mut info: Option<DeviceInfo> = None;
 
-    for device in ls {
-        println!("{device}");
+    'devices: for probed in ls {
+        println!("{probed}");
+        let Some(device) = probed.into_device_info() else {
+            continue;
+        };
 
         for iface in device.interface_descriptors().cloned().collect::<Vec<_>>() {
             println!("  Interface: {:?}", iface.class());
@@ -22,7 +25,7 @@ async fn main() {
             if KeyBoard::check(&device) {
                 info!("Found video interface: {iface:?}");
                 info = Some(device);
-                break;
+                break 'devices;
             }
         }
     }

--- a/usb-host/src/backend/kmod/kcore.rs
+++ b/usb-host/src/backend/kmod/kcore.rs
@@ -16,7 +16,7 @@ use crate::{
     backend::{
         BackendOp,
         kmod::hub::{Hub, HubDevice, HubInfo, HubOp, PortChangeInfo},
-        ty::{DeviceInfoOp, DeviceOp, EventHandlerOp},
+        ty::{DeviceInfoOp, DeviceOp, EventHandlerOp, ProbedDeviceInfoOp},
     },
 };
 
@@ -62,7 +62,7 @@ impl Core {
         out
     }
 
-    async fn _probe_devices(&mut self) -> Result<(bool, Vec<Box<dyn DeviceInfoOp>>), USBError> {
+    async fn _probe_devices(&mut self) -> Result<(bool, Vec<ProbedDeviceInfoOp>), USBError> {
         let mut is_have_new_hub = false;
         let mut out = Vec::new();
 
@@ -87,6 +87,8 @@ impl Core {
                 if let Some(hub_settings) =
                     HubDevice::is_hub(device.descriptor(), device.configuration_descriptors())
                 {
+                    let desc = device.descriptor().clone();
+                    let configs = device.configuration_descriptors().to_vec();
                     let device_inner: Device = device.into();
 
                     let hub_device = HubDevice::new(
@@ -109,6 +111,10 @@ impl Core {
                     let hub_id = self.hubs.alloc(hub);
                     is_have_new_hub = true;
 
+                    let hub_info = Box::new(DeviceInfo::new(device_id, desc, &configs))
+                        as Box<dyn DeviceInfoOp>;
+                    out.push(ProbedDeviceInfoOp::Hub(hub_info));
+
                     info!("Added new hub with id {:?}", hub_id);
                 } else {
                     let desc = device.descriptor().clone();
@@ -119,7 +125,7 @@ impl Core {
                     let device_info = Box::new(DeviceInfo::new(device_id, desc, &configs))
                         as Box<dyn DeviceInfoOp>;
 
-                    out.push(device_info);
+                    out.push(ProbedDeviceInfoOp::Device(device_info));
                 }
             }
         }
@@ -135,7 +141,7 @@ impl Core {
         hub.backend.changed_ports().await
     }
 
-    async fn probe_devices(&mut self) -> Result<Vec<Box<dyn DeviceInfoOp>>, USBError> {
+    async fn probe_devices(&mut self) -> Result<Vec<ProbedDeviceInfoOp>, USBError> {
         let mut result = Vec::new();
 
         loop {
@@ -164,9 +170,7 @@ impl BackendOp for Core {
         .boxed()
     }
 
-    fn device_list<'a>(
-        &'a mut self,
-    ) -> BoxFuture<'a, Result<Vec<Box<dyn DeviceInfoOp>>, USBError>> {
+    fn device_list<'a>(&'a mut self) -> BoxFuture<'a, Result<Vec<ProbedDeviceInfoOp>, USBError>> {
         self.probe_devices().boxed()
     }
 

--- a/usb-host/src/backend/mod.rs
+++ b/usb-host/src/backend/mod.rs
@@ -5,7 +5,7 @@ use alloc::{boxed::Box, vec::Vec};
 use futures::future::{BoxFuture, LocalBoxFuture};
 use usb_if::err::USBError;
 
-use crate::backend::ty::{DeviceInfoOp, DeviceOp};
+use crate::backend::ty::{DeviceInfoOp, DeviceOp, ProbedDeviceInfoOp};
 
 #[cfg(umod)]
 pub mod umod;
@@ -36,8 +36,7 @@ pub(crate) trait BackendOp: Send + Any + 'static {
     fn init<'a>(&'a mut self) -> BoxFuture<'a, Result<(), USBError>>;
 
     /// 探测已连接的设备
-    fn device_list<'a>(&'a mut self)
-    -> BoxFuture<'a, Result<Vec<Box<dyn DeviceInfoOp>>, USBError>>;
+    fn device_list<'a>(&'a mut self) -> BoxFuture<'a, Result<Vec<ProbedDeviceInfoOp>, USBError>>;
 
     fn open_device<'a>(
         &'a mut self,

--- a/usb-host/src/backend/ty/mod.rs
+++ b/usb-host/src/backend/ty/mod.rs
@@ -1,3 +1,4 @@
+use alloc::boxed::Box;
 use core::any::Any;
 use core::fmt::Debug;
 
@@ -26,6 +27,11 @@ pub(crate) trait DeviceInfoOp: Send + Sync + Any + Debug + 'static {
     fn backend_name(&self) -> &str;
     fn descriptor(&self) -> &DeviceDescriptor;
     fn configuration_descriptors(&self) -> &[ConfigurationDescriptor];
+}
+
+pub(crate) enum ProbedDeviceInfoOp {
+    Device(Box<dyn DeviceInfoOp>),
+    Hub(Box<dyn DeviceInfoOp>),
 }
 
 /// USB 设备特征（高层抽象）

--- a/usb-host/src/backend/umod/mod.rs
+++ b/usb-host/src/backend/umod/mod.rs
@@ -3,7 +3,13 @@ use std::{sync::Arc, thread};
 use futures::FutureExt;
 use usb_if::err::USBError;
 
-use crate::{USBHost, backend::BackendOp};
+use crate::{
+    USBHost,
+    backend::{
+        BackendOp,
+        ty::{DeviceInfoOp, ProbedDeviceInfoOp},
+    },
+};
 
 #[macro_use]
 mod err;
@@ -44,13 +50,20 @@ impl Libusb {
         Self { ctx }
     }
 
-    async fn device_list(&mut self) -> Result<Vec<Box<dyn super::ty::DeviceInfoOp>>, USBError> {
+    async fn device_list(&mut self) -> Result<Vec<ProbedDeviceInfoOp>, USBError> {
         let ctx = self.ctx.clone();
         let devices = ctx.device_list()?;
         let mut infos = Vec::new();
         for dev in devices {
             let info = device::DeviceInfo::new(dev)?;
-            infos.push(Box::new(info) as Box<dyn super::ty::DeviceInfoOp>);
+            let is_hub = info.descriptor().class == 0x09;
+            let info = Box::new(info) as Box<dyn super::ty::DeviceInfoOp>;
+            let info = if is_hub {
+                ProbedDeviceInfoOp::Hub(info)
+            } else {
+                ProbedDeviceInfoOp::Device(info)
+            };
+            infos.push(info);
         }
         Ok(infos)
     }
@@ -81,8 +94,7 @@ impl BackendOp for Libusb {
 
     fn device_list<'a>(
         &'a mut self,
-    ) -> futures::future::BoxFuture<'a, Result<Vec<Box<dyn super::ty::DeviceInfoOp>>, USBError>>
-    {
+    ) -> futures::future::BoxFuture<'a, Result<Vec<ProbedDeviceInfoOp>, USBError>> {
         self.device_list().boxed()
     }
 

--- a/usb-host/src/device.rs
+++ b/usb-host/src/device.rs
@@ -21,6 +21,78 @@ pub struct DeviceInfo {
     pub(crate) inner: Box<dyn DeviceInfoOp>,
 }
 
+pub struct HubDeviceInfo {
+    pub(crate) inner: Box<dyn DeviceInfoOp>,
+}
+
+pub enum ProbedDevice {
+    Device(DeviceInfo),
+    Hub(HubDeviceInfo),
+}
+
+impl ProbedDevice {
+    pub fn id(&self) -> usize {
+        match self {
+            Self::Device(info) => info.id(),
+            Self::Hub(info) => info.id(),
+        }
+    }
+
+    pub fn descriptor(&self) -> &DeviceDescriptor {
+        match self {
+            Self::Device(info) => info.descriptor(),
+            Self::Hub(info) => info.descriptor(),
+        }
+    }
+
+    pub fn configurations(&self) -> &[ConfigurationDescriptor] {
+        match self {
+            Self::Device(info) => info.configurations(),
+            Self::Hub(info) => info.configurations(),
+        }
+    }
+
+    pub fn product_id(&self) -> u16 {
+        self.descriptor().product_id
+    }
+
+    pub fn vendor_id(&self) -> u16 {
+        self.descriptor().vendor_id
+    }
+
+    pub fn as_device_info(&self) -> Option<&DeviceInfo> {
+        match self {
+            Self::Device(info) => Some(info),
+            Self::Hub(_) => None,
+        }
+    }
+
+    pub fn into_device_info(self) -> Option<DeviceInfo> {
+        match self {
+            Self::Device(info) => Some(info),
+            Self::Hub(_) => None,
+        }
+    }
+}
+
+impl Debug for ProbedDevice {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Device(info) => f.debug_tuple("ProbedDevice::Device").field(info).finish(),
+            Self::Hub(info) => f.debug_tuple("ProbedDevice::Hub").field(info).finish(),
+        }
+    }
+}
+
+impl Display for ProbedDevice {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        match self {
+            Self::Device(info) => Display::fmt(info, f),
+            Self::Hub(info) => Display::fmt(info, f),
+        }
+    }
+}
+
 impl DeviceInfo {
     pub fn id(&self) -> usize {
         self.inner.id()
@@ -54,6 +126,28 @@ impl DeviceInfo {
     }
 }
 
+impl HubDeviceInfo {
+    pub fn id(&self) -> usize {
+        self.inner.id()
+    }
+
+    pub fn descriptor(&self) -> &DeviceDescriptor {
+        self.inner.descriptor()
+    }
+
+    pub fn configurations(&self) -> &[ConfigurationDescriptor] {
+        self.inner.configuration_descriptors()
+    }
+
+    pub fn product_id(&self) -> u16 {
+        self.descriptor().product_id
+    }
+
+    pub fn vendor_id(&self) -> u16 {
+        self.descriptor().vendor_id
+    }
+}
+
 impl Debug for DeviceInfo {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("DeviceInfo")
@@ -64,7 +158,28 @@ impl Debug for DeviceInfo {
     }
 }
 
+impl Debug for HubDeviceInfo {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("HubDeviceInfo")
+            .field("backend", &self.inner.backend_name())
+            .field("vender_id", &self.inner.descriptor().vendor_id)
+            .field("product_id", &self.inner.descriptor().product_id)
+            .finish()
+    }
+}
+
 impl Display for DeviceInfo {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(
+            f,
+            "{:04x}:{:04x}",
+            self.inner.descriptor().vendor_id,
+            self.inner.descriptor().product_id
+        )
+    }
+}
+
+impl Display for HubDeviceInfo {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(
             f,

--- a/usb-host/src/host.rs
+++ b/usb-host/src/host.rs
@@ -11,7 +11,7 @@ pub use super::backend::kmod::*;
 #[cfg(umod)]
 pub use super::backend::umod::*;
 
-pub use crate::device::{Device, DeviceInfo};
+pub use crate::device::{Device, DeviceInfo, HubDeviceInfo, ProbedDevice};
 
 /// USB 主机控制器
 pub struct USBHost {
@@ -25,11 +25,14 @@ impl USBHost {
         Ok(())
     }
 
-    pub async fn probe_devices(&mut self) -> Result<Vec<DeviceInfo>> {
+    pub async fn probe_devices(&mut self) -> Result<Vec<ProbedDevice>> {
         let device_infos = self.backend.device_list().await?;
         let mut devices = Vec::new();
         for dev in device_infos {
-            let dev_info = DeviceInfo { inner: dev };
+            let dev_info = match dev {
+                ProbedDeviceInfoOp::Device(inner) => ProbedDevice::Device(DeviceInfo { inner }),
+                ProbedDeviceInfoOp::Hub(inner) => ProbedDevice::Hub(HubDeviceInfo { inner }),
+            };
             devices.push(dev_info);
         }
         Ok(devices)


### PR DESCRIPTION
## Summary
- 新增 `ProbedDevice` 枚举（`Device` / `Hub` 变体），让 `probe_devices()` 调用者无需手动检查描述符即可区分 Hub 和普通设备
- 后端层新增 `ProbedDeviceInfoOp` 枚举，kmod 和 umod 后端在探测时自动分类
- 公开导出 `ProbedDevice`、`HubDeviceInfo` 类型
- 更新所有测试和示例代码，使用 `into_device_info()` 过滤 Hub

## Test plan
- [ ] `cargo check -p crab-usb --test test --target aarch64-unknown-none-softfloat` 通过
- [ ] `cargo fmt --all` 无变化
- [ ] `cargo test -p crab-usb --features libusb --test test` 通过（如环境支持）

🤖 Generated with [Claude Code](https://claude.com/claude-code)