### PR TITLE
fix(xhci): set chain bit on ISO TRBs and preserve raw config descriptor

### DIFF
--- a/usb-host/src/backend/kmod/xhci/endpoint.rs
+++ b/usb-host/src/backend/kmod/xhci/endpoint.rs
@@ -115,22 +115,35 @@ impl Endpoint {
 
     fn enque_iso(&mut self, bus_addr: u64, packet_lengths: &[usize]) -> TransferId {
         if packet_lengths.len() <= 1 {
-            self.enque_iso_trb(bus_addr, packet_lengths.first().copied().unwrap_or(0))
+            self.enque_iso_trb(
+                bus_addr,
+                packet_lengths.first().copied().unwrap_or(0),
+                false,
+                true,
+            )
         } else {
             self.enque_iso_multi(bus_addr, packet_lengths)
         }
     }
 
-    fn enque_iso_trb(&mut self, bus_addr: u64, buff_len: usize) -> TransferId {
+    fn enque_iso_trb(
+        &mut self,
+        bus_addr: u64,
+        buff_len: usize,
+        chain: bool,
+        ioc: bool,
+    ) -> TransferId {
         let mut trb = Isoch::new();
         trb.set_data_buffer_pointer(bus_addr as _)
             .set_trb_transfer_length(buff_len as _)
             .set_interrupter_target(0)
-            .set_interrupt_on_completion();
-
-        // if use_sia {
-        //     trb.set_start_isoch_asap(); // 启用SIA
-        // }
+            .set_start_isoch_asap();
+        if chain {
+            trb.set_chain_bit();
+        }
+        if ioc {
+            trb.set_interrupt_on_completion();
+        }
 
         // 创建Isoch TRB
         let trb = transfer::Allowed::Isoch(trb);
@@ -149,7 +162,7 @@ impl Endpoint {
 
                 if index == 0 {
                     // 第一个TRB必须是Isoch TRB
-                    id = self.enque_iso_trb(current_addr, current_size as _);
+                    id = self.enque_iso_trb(current_addr, current_size as _, !is_last, is_last);
                 } else {
                     // 后续TRB使用Normal TRB
                     let mut trb = Normal::new();
@@ -159,6 +172,8 @@ impl Endpoint {
 
                     if is_last {
                         trb.set_interrupt_on_completion();
+                    } else {
+                        trb.set_chain_bit();
                     }
                     let trb = transfer::Allowed::Normal(trb);
                     id = self.enque_trb(trb);

--- a/usb-host/src/backend/umod/device.rs
+++ b/usb-host/src/backend/umod/device.rs
@@ -163,6 +163,7 @@ fn libusb_get_configuration_descriptors(
         string_index: NonZero::new(desc.iConfiguration),
         string: None,
         interfaces,
+        raw: Vec::new(),
     };
     unsafe { libusb_free_config_descriptor(desc) };
     Ok(out)

--- a/usb-if/src/descriptor/mod.rs
+++ b/usb-if/src/descriptor/mod.rs
@@ -178,6 +178,7 @@ pub struct ConfigurationDescriptor {
     pub string_index: Option<NonZero<u8>>,
     pub string: Option<String>,
     pub interfaces: Vec<InterfaceDescriptors>,
+    pub raw: Vec<u8>,
 }
 
 impl ConfigurationDescriptor {
@@ -230,6 +231,7 @@ impl From<parser::ConfigurationDescriptor<'_>> for ConfigurationDescriptor {
             string_index: desc.string_index(),
             interfaces: desc.interfaces().map(InterfaceDescriptors::from).collect(),
             string: None,
+            raw: desc.as_bytes().to_vec(),
         }
     }
 }


### PR DESCRIPTION
## Summary
- xHCI 等时传输：非最后一个 TRB 设置 chain bit，让控制器正确链接多包等时传输；同时启用 SIA (Start Isoch ASAP)
- `ConfigurationDescriptor` 新增 `raw` 字段，保留原始描述符字节

## Test plan
- [ ] `cargo check -p crab-usb --test test --target aarch64-unknown-none-softfloat` 通过
- [ ] UVC 等时传输功能正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)