### PR TITLE
chore: release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ crab-usb = {path = "usb-host", version = "0.7" }
 futures = {version = "0.3", default-features = false}
 log = "0.4"
 thiserror = {version = "2", default-features = false}
-usb-if = {path = "usb-if", version = "0.5" }
+usb-if = {path = "usb-if", version = "0.6" }
 crab-uvc = {path = "usb-device/uvc", version = "0.1" }
 tock-registers = "0.10"
 bare-test = {version = "0.7"}

--- a/usb-host/CHANGELOG.md
+++ b/usb-host/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1](https://github.com/drivercraft/CrabUSB/compare/crab-usb-v0.7.0...crab-usb-v0.7.1) - 2026-04-29
+
+### Fixed
+
+- *(xhci)* set chain bit on ISO TRBs and preserve raw config descriptor ([#69](https://github.com/drivercraft/CrabUSB/pull/69))
+
 ## [0.7.0](https://github.com/drivercraft/CrabUSB/compare/crab-usb-v0.6.2...crab-usb-v0.7.0) - 2026-04-23
 
 ### Other

--- a/usb-host/Cargo.toml
+++ b/usb-host/Cargo.toml
@@ -7,7 +7,7 @@ keywords = ["os", "usb", "xhci", "driver"]
 license = "MIT"
 name = "crab-usb"
 repository = "https://github.com/drivercraft/CrabUSB"
-version = "0.7.0"
+version = "0.7.1"
 
 [features]
 aggressive_usb_reset = []

--- a/usb-if/CHANGELOG.md
+++ b/usb-if/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/drivercraft/CrabUSB/compare/usb-if-v0.5.1...usb-if-v0.6.0) - 2026-04-29
+
+### Fixed
+
+- *(xhci)* set chain bit on ISO TRBs and preserve raw config descriptor ([#69](https://github.com/drivercraft/CrabUSB/pull/69))
+
 ## [0.5.1](https://github.com/drivercraft/CrabUSB/compare/usb-if-v0.5.0...usb-if-v0.5.1) - 2026-01-28
 
 ### Other

--- a/usb-if/Cargo.toml
+++ b/usb-if/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license.workspace = true
 name = "usb-if"
 repository.workspace = true
-version = "0.5.1"
+version = "0.6.0"
 
 [dependencies]
 anyhow = { version = "1", default-features = false}


### PR DESCRIPTION



## 🤖 New release

* `usb-if`: 0.5.1 -> 0.6.0 (⚠ API breaking changes)
* `crab-usb`: 0.7.0 -> 0.7.1 (✓ API compatible changes)

### ⚠ `usb-if` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field ConfigurationDescriptor.raw in /tmp/.tmpuJJCoP/CrabUSB/usb-if/src/descriptor/mod.rs:181
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `usb-if`

<blockquote>

## [0.6.0](https://github.com/drivercraft/CrabUSB/compare/usb-if-v0.5.1...usb-if-v0.6.0) - 2026-04-29

### Fixed

- *(xhci)* set chain bit on ISO TRBs and preserve raw config descriptor ([#69](https://github.com/drivercraft/CrabUSB/pull/69))
</blockquote>

## `crab-usb`

<blockquote>

## [0.7.1](https://github.com/drivercraft/CrabUSB/compare/crab-usb-v0.7.0...crab-usb-v0.7.1) - 2026-04-29

### Fixed

- *(xhci)* set chain bit on ISO TRBs and preserve raw config descriptor ([#69](https://github.com/drivercraft/CrabUSB/pull/69))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).