### PR TITLE
chore: release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,11 +8,11 @@ license = "MIT"
 repository = "https://github.com/drivercraft/CrabUSB"
 
 [workspace.dependencies]
-crab-usb = {path = "usb-host", version = "0.7" }
+crab-usb = {path = "usb-host", version = "0.8" }
 futures = {version = "0.3", default-features = false}
 log = "0.4"
 thiserror = {version = "2", default-features = false}
-usb-if = {path = "usb-if", version = "0.6" }
+usb-if = {path = "usb-if", version = "0.7" }
 crab-uvc = {path = "usb-device/uvc", version = "0.1" }
 tock-registers = "0.10"
 bare-test = {version = "0.7"}

--- a/usb-host/CHANGELOG.md
+++ b/usb-host/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/drivercraft/CrabUSB/compare/crab-usb-v0.7.1...crab-usb-v0.8.0) - 2026-04-30
+
+### Other
+
+- Introduce Queue-Based Transfer API and Unified Endpoint Model ([#71](https://github.com/drivercraft/CrabUSB/pull/71))
+
 ## [0.7.1](https://github.com/drivercraft/CrabUSB/compare/crab-usb-v0.7.0...crab-usb-v0.7.1) - 2026-04-29
 
 ### Fixed

--- a/usb-host/Cargo.toml
+++ b/usb-host/Cargo.toml
@@ -7,7 +7,7 @@ keywords = ["os", "usb", "xhci", "driver"]
 license = "MIT"
 name = "crab-usb"
 repository = "https://github.com/drivercraft/CrabUSB"
-version = "0.7.1"
+version = "0.8.0"
 
 [features]
 aggressive_usb_reset = []

--- a/usb-if/CHANGELOG.md
+++ b/usb-if/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0](https://github.com/drivercraft/CrabUSB/compare/usb-if-v0.6.0...usb-if-v0.7.0) - 2026-04-30
+
+### Other
+
+- Introduce Queue-Based Transfer API and Unified Endpoint Model ([#71](https://github.com/drivercraft/CrabUSB/pull/71))
+
 ## [0.6.0](https://github.com/drivercraft/CrabUSB/compare/usb-if-v0.5.1...usb-if-v0.6.0) - 2026-04-29
 
 ### Fixed

--- a/usb-if/Cargo.toml
+++ b/usb-if/Cargo.toml
@@ -4,7 +4,7 @@ edition.workspace = true
 license.workspace = true
 name = "usb-if"
 repository.workspace = true
-version = "0.6.0"
+version = "0.7.0"
 
 [dependencies]
 anyhow = { version = "1", default-features = false}


### PR DESCRIPTION



## 🤖 New release

* `usb-if`: 0.6.0 -> 0.7.0 (⚠ API breaking changes)
* `crab-usb`: 0.7.1 -> 0.8.0 (⚠ API breaking changes)

### ⚠ `usb-if` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant TransferError:QueueFull in /tmp/.tmpxZmqbY/CrabUSB/usb-if/src/err.rs:8
  variant TransferError:InvalidEndpoint in /tmp/.tmpxZmqbY/CrabUSB/usb-if/src/err.rs:10
  variant TransferError:NoDevice in /tmp/.tmpxZmqbY/CrabUSB/usb-if/src/err.rs:12
  variant TransferError:NotSupported in /tmp/.tmpxZmqbY/CrabUSB/usb-if/src/err.rs:14

--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_missing.ron

Failed in:
  variant TransferError::RequestQueueFull, previously in file /tmp/.tmp2fZLsq/usb-if/src/err.rs:8
```

### ⚠ `crab-usb` breaking changes

```text
--- failure enum_missing: pub enum removed or renamed ---

Description:
A publicly-visible enum cannot be imported by its prior path. A `pub use` may have been removed, or the enum itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_missing.ron

Failed in:
  enum crab_usb::EndpointKind, previously in file /tmp/.tmp2fZLsq/crab-usb/src/backend/ty/ep/mod.rs:26

--- failure inherent_method_missing: pub method removed or renamed ---

Description:
A publicly-visible method or associated fn is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/inherent_method_missing.ron

Failed in:
  Device::ep_ctrl, previously in file /tmp/.tmp2fZLsq/crab-usb/src/device.rs:273
  Device::get_endpoint, previously in file /tmp/.tmp2fZLsq/crab-usb/src/device.rs:338
  Device::ep_ctrl, previously in file /tmp/.tmp2fZLsq/crab-usb/src/device.rs:273
  Device::get_endpoint, previously in file /tmp/.tmp2fZLsq/crab-usb/src/device.rs:338

--- failure struct_missing: pub struct removed or renamed ---

Description:
A publicly-visible struct cannot be imported by its prior path. A `pub use` may have been removed, or the struct itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/struct_missing.ron

Failed in:
  struct crab_usb::EndpointBulkOut, previously in file /tmp/.tmp2fZLsq/crab-usb/src/backend/ty/ep/bulk.rs:41
  struct crab_usb::EndpointInterruptOut, previously in file /tmp/.tmp2fZLsq/crab-usb/src/backend/ty/ep/int.rs:42
  struct crab_usb::EndpointIsoIn, previously in file /tmp/.tmp2fZLsq/crab-usb/src/backend/ty/ep/iso.rs:10
  struct crab_usb::EndpointIsoOut, previously in file /tmp/.tmp2fZLsq/crab-usb/src/backend/ty/ep/iso.rs:75
  struct crab_usb::EndpointBulkIn, previously in file /tmp/.tmp2fZLsq/crab-usb/src/backend/ty/ep/bulk.rs:9
  struct crab_usb::EndpointInterruptIn, previously in file /tmp/.tmp2fZLsq/crab-usb/src/backend/ty/ep/int.rs:9
  struct crab_usb::EndpointControl, previously in file /tmp/.tmp2fZLsq/crab-usb/src/backend/ty/ep/ctrl.rs:12
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `usb-if`

<blockquote>

## [0.7.0](https://github.com/drivercraft/CrabUSB/compare/usb-if-v0.6.0...usb-if-v0.7.0) - 2026-04-30

### Other

- Introduce Queue-Based Transfer API and Unified Endpoint Model ([#71](https://github.com/drivercraft/CrabUSB/pull/71))
</blockquote>

## `crab-usb`

<blockquote>

## [0.8.0](https://github.com/drivercraft/CrabUSB/compare/crab-usb-v0.7.1...crab-usb-v0.8.0) - 2026-04-30

### Other

- Introduce Queue-Based Transfer API and Unified Endpoint Model ([#71](https://github.com/drivercraft/CrabUSB/pull/71))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).