### PR TITLE
fix(kmod): propagate DMA mapping errors and pre-check ring capacity

### DIFF
--- a/usb-host/src/backend/kmod/transfer.rs
+++ b/usb-host/src/backend/kmod/transfer.rs
@@ -3,6 +3,7 @@ use core::ptr::NonNull;
 use alloc::vec::Vec;
 use dma_api::DmaDirection;
 use usb_if::endpoint::TransferRequest;
+use usb_if::err::TransferError;
 use usb_if::transfer::Direction;
 
 use crate::{
@@ -18,7 +19,7 @@ impl Transfer {
         kind: TransferKind,
         direction: Direction,
         buff: Option<(NonNull<u8>, usize)>,
-    ) -> Self {
+    ) -> Result<Self, TransferError> {
         let dma_direction = match direction {
             Direction::In => DmaDirection::FromDevice,
             Direction::Out => DmaDirection::ToDevice,
@@ -27,22 +28,25 @@ impl Transfer {
             let slice = unsafe { core::slice::from_raw_parts_mut(ptr.as_ptr(), len) };
             Some(
                 dma.map_single_array(slice, ALIGN, dma_direction)
-                    .expect("DMA mapping failed"),
+                    .map_err(|err| TransferError::Other(anyhow!("DMA mapping failed: {err}")))?,
             )
         } else {
             None
         };
 
-        Self {
+        Ok(Self {
             kind,
             direction,
             mapping,
             transfer_len: 0,
             iso_packet_actual_lengths: Vec::new(),
-        }
+        })
     }
 
-    pub(crate) fn from_request(dma: &Kernel, request: TransferRequest) -> Self {
+    pub(crate) fn from_request(
+        dma: &Kernel,
+        request: TransferRequest,
+    ) -> Result<Self, TransferError> {
         let (kind, direction, buffer) = request.into();
         let buff = buffer.map(|buffer| (buffer.ptr, buffer.len));
         Self::new(dma, kind, direction, buff)

--- a/usb-host/src/backend/kmod/xhci/endpoint.rs
+++ b/usb-host/src/backend/kmod/xhci/endpoint.rs
@@ -276,13 +276,28 @@ impl Endpoint {
         }
         Ok(())
     }
+
+    fn required_trbs_for_request(request: &TransferRequest) -> usize {
+        match request {
+            TransferRequest::Control { buffer, .. } => {
+                if buffer.is_some_and(|buffer| buffer.len > 0) {
+                    3
+                } else {
+                    2
+                }
+            }
+            TransferRequest::Bulk { .. } | TransferRequest::Interrupt { .. } => 1,
+            TransferRequest::Isochronous { packets, .. } => packets.len().max(1),
+        }
+    }
 }
 
 impl EndpointOp for Endpoint {
     fn submit_request(&mut self, request: TransferRequest) -> Result<RequestId, TransferError> {
-        let transfer = Transfer::from_request(&self.kernel, request);
-        let required_trbs = Self::required_trbs(&transfer);
+        let required_trbs = Self::required_trbs_for_request(&request);
         self.ensure_ring_capacity(required_trbs)?;
+        let transfer = Transfer::from_request(&self.kernel, request)?;
+        debug_assert_eq!(required_trbs, Self::required_trbs(&transfer));
 
         let mut data_bus_addr = 0;
         if transfer.buffer_len() > 0 {


### PR DESCRIPTION
## Summary
- `Transfer::new`/`from_request` 返回 `Result<Self, TransferError>` 而非 panic，DMA 映射失败时正确传播错误
- 新增 `required_trbs_for_request` 方法在 DMA 映射前计算所需 TRB 数量，避免映射成功但 ring 满时的资源泄漏
- 加入 `debug_assert` 确保 `required_trbs_for_request` 与 `required_trbs` 计算结果一致

## Test plan
- [ ] `cargo check -p crab-usb --test test --target aarch64-unknown-none-softfloat` 通过
- [ ] `cargo fmt --all` 无变更
- [ ] `cargo test -p crab-usb --test test --target aarch64-unknown-none-softfloat` 通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)